### PR TITLE
prevent error on getPosition

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -643,6 +643,10 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
        position = CMTimeGetSeconds(time);
     }
 
+    if (isnan(position)){
+        position = -1;
+    }
+
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:position];
 
     [self onStatus:MEDIA_POSITION mediaId:mediaId param:@(position)];


### PR DESCRIPTION
When I try to get the position of an audio that had an error while loading, the crash appose exponentially because it can not cast the time = none